### PR TITLE
Fix links to upscaled images

### DIFF
--- a/data/image_captions.json
+++ b/data/image_captions.json
@@ -25,8 +25,8 @@
     "message" : "The first good upscale of pack.png. Created using a custom AI."
   },
   {
-    "thumbnail_path" : "thumbnails/thumbnail_upscale.png",
-    "image_path": "gallery/upscale.png",
+    "thumbnail_path" : "thumbnails/thumbnail_upscale2.jpg",
+    "image_path": "gallery/upscale2.jpg",
     "message" : "The currently best upscale of pack.png. Created using a custom AI."
   },
   {


### PR DESCRIPTION
Both upscaled image links on the website gallery pointed to the same image.