### PR TITLE
Fix some minor punctuational and grammatical issues

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -19,7 +19,7 @@
 {% block content %}
 <div class="container">
     <h1 class="text-center"> The pack.png project<br><small class="text-muted">to find the seed of the most iconic image
-            in minecraft
+            in Minecraft
             history</small></h1>
     <img class="image-wrapper float-left pr-3" src="{{url_for('static', filename='pack.png')}}"
         alt="original pack.png" />

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -32,7 +32,7 @@
     </div>
     <div>
         <h3>3257840388504953787</h3>
-        That's it, thats the seed. The coordinates are x=49, z=0.
+        That's it, that's the seed. The coordinates are x=49, z=0.
     </div>
     <br>
 </div>

--- a/data/contributors.json
+++ b/data/contributors.json
@@ -46,7 +46,7 @@
     "Other people with good ideas": [
         {
             "name": "James Bond",
-            "comment": "Upscaling the packpng image",
+            "comment": "upscaled the packpng image",
             "discord_name": "James Bond#0007",
             "profile_url": "https://discordapp.com/users/212445217763229699"
         },

--- a/data/contributors.json
+++ b/data/contributors.json
@@ -1,5 +1,5 @@
 {
-    "Core team:": [
+    "Core team": [
         {
             "name": "Bálint",
             "comment": "",

--- a/data/faq.json
+++ b/data/faq.json
@@ -16,7 +16,7 @@
         "A": "You can go <a href=\"https://packpng.com/\">here</a> to see a incomplete list of seeds we have tried. People have tried way more than these, but these are the important ones. Sadly, trying seeds isn't really helpful."
     },
     {
-        "Q": "How can I help crack the seed",
+        "Q": "How can I help crack the seed?",
         "A": "While we are grateful there are many people willing to help, we can't have everyone helping at once, or it would be chaos. So, rather than asking how you can help straight away, try to self-evaluate what you may be able to do to help before asking, then ask \"how can I help with X\"? Realistically at this point, if you are not a skilled programmer, you probably can't help, sorry."
     },
     {
@@ -32,7 +32,7 @@
         "A": "Head over to the <a href=\"https://packpng.com/about\">about</a> page to see the contributors to this page!"
     },
     {
-        "Q": "Do you have enough processing power? I could rent out stuff from X",
+        "Q": "Do you have enough processing power? I could rent out stuff from X.",
         "A": "Yes, we have plenty of processing power. To be exact, 2-6 NVIDIA DGX-2 Supercomputers."
     },
     {

--- a/data/image_captions.json
+++ b/data/image_captions.json
@@ -7,7 +7,7 @@
   {
     "thumbnail_path" : "thumbnails/thumbnail_ingame_pixelart2.png",
     "image_path": "gallery/ingame_pixelart2.png",
-    "message" : "Pixel art of pack.png in minecraft"
+    "message" : "Pixel art of pack.png in Minecraft"
   },
   {
     "thumbnail_path" : "thumbnails/thumbnail_ingame_pixelart.png",


### PR DESCRIPTION
It was just really bothering me :(
I would've written a better description but my computer is about to run out of power.

Edit: My computer has power again.
- Added an apostrophe to "thats the seed." on the main page.
- Capitalized Minecraft in the subtitle on the main page.
- Added a question mark to "How can I help crack the seed" in the FAQ.
- Added a period to "I could rent stuff out from X" in the FAQ.
- Removed the colon from "Core Team:" in the Contributors page to be consistent with other headings.
- Changed "Upscaling" to "upscaled" in the Contributors page.
- Capitalized "minecraft" in the captions of one of the photos. 

Edit 2: I realize now that I was supposed to request to merge this into laundmo:deploy, but I'm not quite sure I'm doing it right while trying to switch the branch to merge it into.